### PR TITLE
Add setup-log-command wrapper

### DIFF
--- a/setup-log/setup-log
+++ b/setup-log/setup-log
@@ -46,6 +46,10 @@ def process_args():
                         help="override current date when adding new title. This option is " +
                              "ignored if '-t' is not present")
 
+    parser.add_argument('-s', metavar="SUBLEVEL", dest='sublevel',
+                        type=int, default=1,
+                        help="sublevel of the bullet point")
+
     parser.add_argument('-c', metavar="COMMAND", dest='command',
                         help="add a command as a sub-bullet")
 
@@ -89,7 +93,7 @@ def add_new_topic(log_marker, log_lines, title, date):
     log_lines[setup_log_start + 1:setup_log_start + 1] = ["", topic_heading, topic_underline, ""]
 
 
-def add_new_message(log_marker, log_lines, message, command):
+def add_new_message(log_marker, log_lines, message, command, sublevel):
     new_message_line = find_marker(log_marker, log_lines)
 
     while new_message_line + 1 < len(log_lines):
@@ -109,14 +113,14 @@ def add_new_message(log_marker, log_lines, message, command):
         print("Warning: last topic date different from current system date, " +
               "consider adding new topic", file=sys.stderr)
 
-    new_message = ["  * {}".format(message)]
+    new_message = [('  '*sublevel) + "* {}".format(message)]
     if command is not None:
-        new_message.append("    * `{}`".format(command))
+        new_message.append(('  '*(sublevel+1)) + "* `{}`".format(command))
 
     # This is where the first message should be.
     new_message_line += 1
 
-    if new_message_line < len(log_lines) and log_lines[new_message_line].startswith('  *'):
+    if new_message_line < len(log_lines) and re.match(" +\* ", log_lines[new_message_line]):
         # Indeed, the first message is here. Find line after last message in the first topic
         while new_message_line < len(log_lines) and log_lines[new_message_line] != "":
             new_message_line += 1
@@ -156,7 +160,7 @@ def main():
 
     if args.new_title:
         add_new_topic(config['log_marker'], log_lines, args.new_title, args.date)
-    add_new_message(config['log_marker'], log_lines, args.message, args.command)
+    add_new_message(config['log_marker'], log_lines, args.message, args.command, args.sublevel)
 
     write_log(config['setup_log_path'], log_lines)
 

--- a/setup-log/setup-log-command
+++ b/setup-log/setup-log-command
@@ -2,8 +2,9 @@
 
 DEFAULT_SUBLEVEL=2
 
-if [ $# -eq 0 ]; then
-    echo "usage: setup-log-command <command_to_execute_and_log>"
+if [ ! $# -eq 1 ]; then
+    echo "usage: setup-log-command '<command_to_execute_and_log>'"
+    echo "Note: the command must be in quotes!"
     exit 1
 fi
 

--- a/setup-log/setup-log-command
+++ b/setup-log/setup-log-command
@@ -7,6 +7,6 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-./setup-log -s $DEFAULT_SUBLEVEL '`'"$@"'`'
+setup-log -s $DEFAULT_SUBLEVEL '`'"$@"'`'
 sh -c "$@"
 exit $?

--- a/setup-log/setup-log-command
+++ b/setup-log/setup-log-command
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+DEFAULT_SUBLEVEL=2
+
+if [ $# -eq 0 ]; then
+    echo "usage: setup-log-command <command_to_execute_and_log>"
+    exit 1
+fi
+
+./setup-log -s $DEFAULT_SUBLEVEL '`'"$@"'`'
+sh -c "$@"
+exit $?


### PR DESCRIPTION
This wrapper logs command and then executes it. It is not perfect, however, because the command must be supplied as a single argument to this script. On the other hand, it executes it inside a shell, which means commands like 'cd /usr/ports/sysutils/whatever && make install clean' will work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trojsten/sysadmin-script-collection/12)

<!-- Reviewable:end -->
